### PR TITLE
Fix ICBC Integration

### DIFF
--- a/python/form_handler/actions.py
+++ b/python/form_handler/actions.py
@@ -445,9 +445,7 @@ def prep_icbc_payload(**args)->tuple:
             date_of_driving=date_of_driving.strftime('%Y%m%d')
             tmp_payload["violationDate"]=date_of_driving
         if "time_of_driving" in event_data: 
-            tmp_time_str=event_data["time_of_driving"]
-            tmp_time_str=tmp_time_str[:2] + ":" + tmp_time_str[2:]
-            tmp_payload["violationTime"]=tmp_time_str.replace(" ", "")
+            tmp_payload["violationTime"]=event_data["time_of_driving"].replace(" ", "")
 
         # TODO: get agency from user table for the event
         if "agency" in user_data: 

--- a/roadside-forms-frontend/frontend_web_app/src/components/Event/ConfirmationStep/confirmationStep.js
+++ b/roadside-forms-frontend/frontend_web_app/src/components/Event/ConfirmationStep/confirmationStep.js
@@ -86,21 +86,6 @@ export const ConfirmationStep = () => {
     return `${year}-${month}-${day}`;
   };
 
-  const formatStrToTimeFormat = (timeString) => {
-    const formattedTime = `${timeString.substring(0, 2)}:${timeString.substring(
-      2,
-      4
-    )}`;
-    return formattedTime;
-  };
-
-  const formatTime = (timeString) => {
-    const date = new Date(timeString);
-    const hours = String(date.getHours()).padStart(2, "0");
-    const minutes = String(date.getMinutes()).padStart(2, "0");
-    return `${hours}:${minutes}`;
-  };
-
   let label = generateLabel();
   let certifyNoticeText = generateCertifyNotice();
 
@@ -164,7 +149,7 @@ export const ConfirmationStep = () => {
                   section 90.3 of the Motor Vehicle Act for a period of 12
                   hours, commencing at:{" "}
                   {dateOfDriving ? formatDate(dateOfDriving) : "N/A"},
-                  {timeOfDriving ? formatStrToTimeFormat(timeOfDriving) : "N/A"}
+                  {timeOfDriving ? timeOfDriving : "N/A"}
                 </span>
               )}
               {values["TwentyFourHour"] && (
@@ -173,7 +158,7 @@ export const ConfirmationStep = () => {
                   Vehicle Act from driving a motor vehicle for 24 hours
                   commencing at:{" "}
                   {dateOfDriving ? formatDate(dateOfDriving) : "N/A"},
-                  {timeOfDriving ? formatStrToTimeFormat(timeOfDriving) : "N/A"}
+                  {timeOfDriving ? timeOfDriving : "N/A"}
                 </span>
               )}
             </div>


### PR DESCRIPTION
The added ":" between HH and MM in the user input field caused an integration error with ICBC wherein there was an extra ":" added between the hours and minutes.