### PR TITLE
Various Fixes

### DIFF
--- a/roadside-forms-frontend/frontend_web_app/src/components/Event/validationSchema.js
+++ b/roadside-forms-frontend/frontend_web_app/src/components/Event/validationSchema.js
@@ -732,10 +732,7 @@ export const validationSchema = Yup.object().shape(
         "at_least_one_impoundment_reason",
         "Please select at least one option from the list of Impoundment for Driving Behaviour",
         function (value) {
-          if (
-            this.parent.VI &&
-            (this.parent.irp_impound === "NO" || this.parent.TwentyFourHour)
-          ) {
+          if (this.parent.VI && this.parent.irp_impound === "NO") {
             // At least one is required
             return (
               this.parent.excessive_speed ||

--- a/roadside-forms-frontend/frontend_web_app/src/components/Event/validationSchema.js
+++ b/roadside-forms-frontend/frontend_web_app/src/components/Event/validationSchema.js
@@ -732,7 +732,10 @@ export const validationSchema = Yup.object().shape(
         "at_least_one_impoundment_reason",
         "Please select at least one option from the list of Impoundment for Driving Behaviour",
         function (value) {
-          if (this.parent.VI && this.parent.irp_impound === "NO") {
+          if (
+            this.parent.VI &&
+            (this.parent.irp_impound === "NO" || this.parent.TwentyFourHour)
+          ) {
             // At least one is required
             return (
               this.parent.excessive_speed ||

--- a/roadside-forms-frontend/frontend_web_app/src/components/Forms/Print/print_layout.json
+++ b/roadside-forms-frontend/frontend_web_app/src/components/Forms/Print/print_layout.json
@@ -1107,7 +1107,7 @@
       "POLICE_COPY": {
         "field_type": "always",
         "field_name": "",
-        "field_value": "POLICE/SUPERINTENDENT COPY",
+        "field_value": "POLICE/ICBC COPY",
         "classNames": "fontSmall",
         "start": {
           "x": 31,
@@ -2767,7 +2767,7 @@
       "POLICE_COPY": {
         "field_type": "always",
         "field_name": "",
-        "field_value": "POLICE/SUPERINTENDENT COPY",
+        "field_value": "POLICE/ICBC COPY",
         "classNames": "fontSmall",
         "start": {
           "x": 30,

--- a/roadside-forms-frontend/frontend_web_app/src/components/Forms/Print/svgPrint.scss
+++ b/roadside-forms-frontend/frontend_web_app/src/components/Forms/Print/svgPrint.scss
@@ -92,7 +92,7 @@ $font_path: ("../../../assets");
     page-break-before: always;
 
     &--landscape {
-      transform: rotate(-90deg) scale(1.12) translate(-125px);
+      transform: rotate(-90deg) scale(1.08) translate(-125px, 14px);
       display: block !important;
     }
     &--portrait {


### PR DESCRIPTION
Fixes:
- Missing validation rule for VI + 24h impoundment reason
- Updated POLICE/SUPERINTENDENT COPY text to POLICE/ICBC COPY on 24h + 12h forms
- Fixed issue where top of form was being cut off during print on landscape-oriented forms