### PR TITLE
Never fetch existing form ID for user

### DIFF
--- a/roadside-forms-frontend/frontend_web_app/src/components/Dashboard/Dashboard.js
+++ b/roadside-forms-frontend/frontend_web_app/src/components/Dashboard/Dashboard.js
@@ -288,7 +288,8 @@ export const Dashboard = () => {
 
     if (staticDataLoaded) {
       if (isConnected) {
-        fetchCurrentIDs().then(() => fetchNeededIDs());
+        fetchNeededIDs();
+        // fetchCurrentIDs().then(() => );
       }
     }
   }, [staticDataLoaded, isConnected]);

--- a/roadside-forms-frontend/frontend_web_app/src/db.js
+++ b/roadside-forms-frontend/frontend_web_app/src/db.js
@@ -33,6 +33,9 @@ const initDB = async () => {
 
 initDB()
   .then(() => {
+    db.formID.clear().then(() => {
+      console.log("Form ID's Cleared.");
+    });
     console.log("Idexed DB is open");
   })
   .catch(function (e) {


### PR DESCRIPTION
No longer fetch exisiting form ID's and just issue new ones. As well as purging all existing form id's in the indexeddb.