### PR TITLE
Set minimum viewport size for Stage Two documents

### DIFF
--- a/roadside-forms-frontend/frontend_web_app/src/components/Event/createEvent.js
+++ b/roadside-forms-frontend/frontend_web_app/src/components/Event/createEvent.js
@@ -666,6 +666,7 @@ export const CreateEvent = () => {
               formType={form}
               values={valuesCopy}
               impoundLotOperators={impoundAtom}
+              renderStage={renderStage}
             />
           );
         }
@@ -866,7 +867,7 @@ export const CreateEvent = () => {
       case 3:
         return <PoliceDetails />;
       case 4:
-        return renderSVGForm(values, "stageTwo");
+        return <div style={{ minWidth: "1640px" }}>{renderSVGForm(values, "stageTwo")}</div>;
       // Add more cases for each page
       default:
         return null;

--- a/roadside-forms-frontend/frontend_web_app/src/components/Forms/Print/svgPrint.js
+++ b/roadside-forms-frontend/frontend_web_app/src/components/Forms/Print/svgPrint.js
@@ -11,14 +11,39 @@ export const SVGprint = ({
   formType,
   values,
   impoundLotOperators,
+  renderStage,
 }) => {
   const formFields = formFieldLayout[formLayout][formType];
   const allFormFields = formFieldLayout[formLayout]["fields"];
   const viewBox = formFieldLayout[formLayout]["viewbox"];
+  var svgStyle = {}
 
   if (Object.keys(values).length) {
+    if (renderStage === "stageTwo") {
+      if (formLayout === "TwelveHour") {
+        svgStyle = {
+          marginTop: "28px",
+        }
+      }
+      else if (formLayout === "TwentyFourHour") {
+        svgStyle = {
+          marginLeft: "0px",
+          marginRight: "0px",
+          marginTop: "28px",
+          marginBottom: "0px"
+        }
+      }
+      else if (formLayout === "VI") {
+        svgStyle = {
+          marginLeft: "-430px",
+          marginRight: "-280px",
+          marginTop: "50px",
+          marginBottom: "40px"
+        }
+      }
+    }
     return (
-      <div>
+      <div style={ svgStyle }>
         <svg
           viewBox={viewBox}
           xmlns="http://www.w3.org/2000/svg"


### PR DESCRIPTION
Preliminary fix for DF-2859 that sets the "minSize" CSS attribute to ensure that the browser's canvas meets a minimum viable threshold to produce a high-quality SVG for conversion into PDF. Additional tweaks made to snip off the blank parts of SVGs so that the PDFs will better fit onto US Letter 8.5" x 11" paper.