### PR TITLE
Fix when VI and 12/24 are selected DF-3059

### DIFF
--- a/roadside-forms-frontend/frontend_web_app/src/components/Event/validationSchema.js
+++ b/roadside-forms-frontend/frontend_web_app/src/components/Event/validationSchema.js
@@ -781,7 +781,9 @@ export const validationSchema = Yup.object().shape(
         "at_least_one_impoundment_reason",
         "Please select at least one option from the list of Impoundment for Driving Behaviour",
         function (value) {
-          if (this.parent.VI && this.parent.irp_impound === "NO") {
+          console.log(this.parent)
+          if (this.parent.VI && 
+            (this.parent.TwelveHour || this.parent.TwentyFourHour || this.parent.irp_impound === "NO")) {
             // At least one is required
             return (
               this.parent.excessive_speed ||

--- a/roadside-forms-frontend/frontend_web_app/src/components/Event/validationSchema.js
+++ b/roadside-forms-frontend/frontend_web_app/src/components/Event/validationSchema.js
@@ -781,7 +781,6 @@ export const validationSchema = Yup.object().shape(
         "at_least_one_impoundment_reason",
         "Please select at least one option from the list of Impoundment for Driving Behaviour",
         function (value) {
-          console.log(this.parent)
           if (this.parent.VI && 
             (this.parent.TwelveHour || this.parent.TwentyFourHour || this.parent.irp_impound === "NO")) {
             // At least one is required


### PR DESCRIPTION
When the user issues a VI and 12/24HR form, the user must select at least one option from the list of "Impoundment for Driving Behaviour"

[DF-3059](https://justice.gov.bc.ca/jirarsi/browse/DF-3059)
