### PR TITLE
Fix: Adding Form Title

### DIFF
--- a/python/prohibition_web_svc/middleware/form_middleware.py
+++ b/python/prohibition_web_svc/middleware/form_middleware.py
@@ -315,9 +315,18 @@ def get_form_statistics(**kwargs) -> tuple:
                 else_=0
             )).label('available_forms')
         ).group_by(Form.form_type).order_by(Form.form_type).all()
+        
+        form_names = {
+                '12Hour': '12 Hour Suspension (MV2906)',
+                '24Hour': '24 Hour Prohibition (MV2634E)',
+                'VI': 'Vehicle Impoundment (MV2721 / MV2722)',
+                'IRP': 'IRP (MV2723 / MV2724)',
+            }
+        
 
         stats = [
             {
+                'form_name': form_names.get(r.form_type, f"Form Type: {r.form_type}"),
                 'form_type': r.form_type,
                 'total_forms': r.total_forms,
                 'leased_forms': r.leased_forms,

--- a/roadside-forms-frontend/frontend_web_app/src/components/userAdminDashboard/formStatistics.js
+++ b/roadside-forms-frontend/frontend_web_app/src/components/userAdminDashboard/formStatistics.js
@@ -48,7 +48,7 @@ export const FormStatistics = () => {
         {formData.map((form) => (
           <Col key={form.form_type} lg={6} className="mb-4">
             <Card>
-              <Card.Header as="h5">{form.form_type} Forms</Card.Header>
+              <Card.Header as="h5">{form.form_name}</Card.Header>
               <Card.Body>
                 <div className={`circle-container ${getStatusClass(form.available_forms)}`}>
                   <div className="circle total">


### PR DESCRIPTION
Issue#: https://jag.gov.bc.ca/jirarsi/browse/DF-3081

Change request from Darell

1) Added form titles to each form types to display in dashboard

12 Hour Suspension (MV2906)
24 Hour Prohibition (MV2634E)
Vehicle Impoundment (MV2721 / MV2722)
IRP (MV2723 / MV2724)

![image](https://github.com/user-attachments/assets/bca6bf36-b0ca-4b3b-bb23-383e93dc3068)
