### PR TITLE
Upgrading PyJWT to parse tokens in RSA-OAEP algorithm

### DIFF
--- a/python/prohibition_web_svc/requirements.txt
+++ b/python/prohibition_web_svc/requirements.txt
@@ -35,7 +35,7 @@ PyMeeus==0.5.12
 pyparsing==3.0.6
 pytest==6.2.2
 python-dateutil==2.8.2
-python-jose==3.3.0
+python-jose==3.4.0
 python-json-logger==2.0.1
 python-keycloak==3.0.0
 psycopg2-binary==2.9.6
@@ -53,7 +53,7 @@ Werkzeug==2.3.7
 xmltodict==0.13.0
 pytest-cov==4.1.0
 minio==7.2.8
-Pillow==10.0.1
+Pillow==10.2.0
 PyMuPDF==1.23.3
 pyaes==1.6.1
 pbkdf2==1.3

--- a/python/prohibition_web_svc/requirements.txt
+++ b/python/prohibition_web_svc/requirements.txt
@@ -30,7 +30,7 @@ pluggy==0.13.1
 py==1.11.0
 pyasn1==0.4.8
 pycparser==2.21
-PyJWT==2.4.0
+PyJWT==2.10.1
 PyMeeus==0.5.12
 pyparsing==3.0.6
 pytest==6.2.2


### PR DESCRIPTION
ISSUE#: https://jira.justice.gov.bc.ca/browse/DF-3105

To access DigitalForms prohibition svc APIs from Formsflow(custom realm) we need to update prohibition svc and Digitalform front end(may be obsolete in future) to use custom realm.
Related to that :
Upgrading PyJWT to parse tokens in RSA-OAEP algorithm

Also fixing two critical vulnerabilities:

Pillow from 10.0.1  to 10.2.0
python-jose from 3.3.0 to 3.4.0