### PR TITLE
Adding an end slash to service worker scope

### DIFF
--- a/roadside-forms-frontend/frontend_web_app/src/serviceWorkerRegistration.js
+++ b/roadside-forms-frontend/frontend_web_app/src/serviceWorkerRegistration.js
@@ -57,7 +57,7 @@ export function register(config) {
 function registerValidSW(swUrl, config) {
   navigator.serviceWorker
     .register(swUrl, {
-      scope: '/roadside-forms'
+      scope: '/roadside-forms/'
     })
     .then((registration) => {
       registration.onupdatefound = () => {
@@ -137,7 +137,7 @@ export function unregister() {
       .then((registration) => {
         // When unregistering, we should target the specific scope
         // This ensures we only unregister our roadside-forms service worker
-        if (registration.scope.includes('/roadside-forms')) {
+        if (registration.scope.includes('/roadside-forms/')) {
           registration.unregister();
         }
       })


### PR DESCRIPTION
To resolve the below error

`serviceWorkerRegistration.js:100 Error during service worker registration: SecurityError: Failed to register a ServiceWorker for scope ('https://dev.jag.gov.bc.ca/roadside-forms') with script ('https://dev.jag.gov.bc.ca/roadside-forms/service-worker.js'): The path of the provided scope ('/roadside-forms') is not under the max scope allowed ('/roadside-forms/'). Adjust the scope, move the Service Worker script, or use the Service-Worker-Allowed HTTP header to allow the scope.`

adding an end slash to service worker scope