### PR TITLE
DF-3211 fix error sending null full address to RIDE

### DIFF
--- a/python/common/ride_actions.py
+++ b/python/common/ride_actions.py
@@ -214,7 +214,7 @@ def fill_location(args, eventPayload):
         eventPayload["locationRequestPayload"]["latitude"] = args['event_data']['latitude']
         eventPayload["locationRequestPayload"]["longitude"] = args['event_data']['longitude']
         eventPayload["locationRequestPayload"]["requestedAddress"] = args['event_data']['requested_address']
-        eventPayload["locationRequestPayload"]["fullAddress"] = args['event_data']['full_address']
+        eventPayload["locationRequestPayload"]["fullAddress"] = args['event_data']['full_address'] or 'NA'
 
 
 def fill_common_payload_record(args, payloadRecord):


### PR DESCRIPTION
Fix error caused by NULL value in the field full_address.